### PR TITLE
add local __repr__() to Document and Query

### DIFF
--- a/bearfield/document.py
+++ b/bearfield/document.py
@@ -196,6 +196,10 @@ class Document(six.with_metaclass(DocumentBuilder, object)):
         self._attrs = {}
         self._dirty = set()
 
+    def __repr__(self):
+        attrs = ['{}={}'.format(name, repr(value)) for name, value in self._encode().items()]
+        return '{}({})'.format(self.__class__.__name__, ', '.join(attrs))
+
     def save(self, connection=None, **options):
         """
         Save the model to the database. Effectively performs an insert if the _id field is None and

--- a/bearfield/query.py
+++ b/bearfield/query.py
@@ -76,5 +76,8 @@ class Query(object):
             return self.criteria == query.criteria
         return False
 
+    def __repr__(self):
+        return 'Q({})'.format(dict(self.criteria))
+
 
 Q = Query


### PR DESCRIPTION
```
from bearfield import Document, Q, Field

class Example(Document):
    a = Field(str)
    b = Field(str)

print(Example(a='a', b=1))
# output: Example(a='a', b='1')

print(Q({'a': 1})
# output: Q({'a': 1}

print(Q({'a': Example(a=1)}))
# output: Q({'a': Example(a='1')})
```